### PR TITLE
Added download_file method to utils.io

### DIFF
--- a/model_toolkit/utils/io.py
+++ b/model_toolkit/utils/io.py
@@ -14,7 +14,7 @@ def load_pickle(path: Path):
         return pickle.load(f)
 
 
-def download_file(url, output_dir='', output_filename=None):
+def download_file(url, output_dir='', output_filename=None, overwrite=False):
     """Downloads a file to the filesystem.
     
     Args:
@@ -23,6 +23,8 @@ def download_file(url, output_dir='', output_filename=None):
         output_filename: a `str`, what to name the downloaded file.
             If this value is 'None', the filename is extracted from the URL.
             Default is 'None'.
+        overwrite: a `bool`, indicates whether to overwrite the file if 
+            it already exists, default is 'False'
     """
     output_dir = Path(output_dir)
     os.makedirs(output_dir, exist_ok=True)
@@ -30,6 +32,10 @@ def download_file(url, output_dir='', output_filename=None):
     output_filename = output_filename or url.split('/')[-1]
     output_filepath = output_dir / output_filename
     
+    if output_filepath.exists() and not overwrite:
+        print(f"File {str(output_filepath)} already exists, nothing to do.")
+        return
     bytestream = urllib.request.urlopen(url)
     with open(output_filepath, 'w+b') as output_file:
         output_file.write(bytestream.read())
+        print(f"File saved to {str(output_filepath)}.")

--- a/model_toolkit/utils/io.py
+++ b/model_toolkit/utils/io.py
@@ -1,6 +1,8 @@
 from typing import Any
 from pathlib import Path
 import pickle
+import os, urllib
+
 
 def dump_pickle(obj: Any, path: Path):
     with open(path, 'w+b') as f:
@@ -10,3 +12,24 @@ def dump_pickle(obj: Any, path: Path):
 def load_pickle(path: Path):
     with open(path, 'rb') as f:
         return pickle.load(f)
+
+
+def download_file(url, output_dir='', output_filename=None):
+    """Downloads a file to the filesystem.
+    
+    Args:
+        url: a `str`, a URL pointing to the file to download
+        output_dir: a `str` or `Path`, the path to the download directory
+        output_filename: a `str`, what to name the downloaded file.
+            If this value is 'None', the filename is extracted from the URL.
+            Default is 'None'.
+    """
+    output_dir = Path(output_dir)
+    os.makedirs(output_dir, exist_ok=True)
+    
+    output_filename = output_filename or url.split('/')[-1]
+    output_filepath = output_dir / output_filename
+    
+    bytestream = urllib.request.urlopen(url)
+    with open(output_filepath, 'w+b') as output_file:
+        output_file.write(bytestream.read())

--- a/model_toolkit/utils/io.py
+++ b/model_toolkit/utils/io.py
@@ -14,6 +14,9 @@ def load_pickle(path: Path):
         return pickle.load(f)
 
 
+def remove_url_args(url):
+    return url.split('?')[0]
+
 def download_file(url, output_dir='', output_filename=None, overwrite=False):
     """Downloads a file to the filesystem.
     
@@ -29,13 +32,14 @@ def download_file(url, output_dir='', output_filename=None, overwrite=False):
     output_dir = Path(output_dir)
     os.makedirs(output_dir, exist_ok=True)
     
-    output_filename = output_filename or url.split('/')[-1]
+    output_filename = output_filename or remove_url_args(url).split('/')[-1]
     output_filepath = output_dir / output_filename
     
     if output_filepath.exists() and not overwrite:
         print(f"File {str(output_filepath)} already exists, nothing to do.")
-        return
-    bytestream = urllib.request.urlopen(url)
-    with open(output_filepath, 'w+b') as output_file:
-        output_file.write(bytestream.read())
-        print(f"File saved to {str(output_filepath)}.")
+    else:
+        bytestream = urllib.request.urlopen(url)
+        with open(output_filepath, 'w+b') as output_file:
+            output_file.write(bytestream.read())
+            print(f"File saved to {str(output_filepath)}.")
+    return str(output_filepath.resolve())


### PR DESCRIPTION
Added method:
```python
def download_file(url, output_dir='', output_filename=None, overwrite=False):
    """Downloads a file to the filesystem.
    
    Args:
        url: a `str`, a URL pointing to the file to download
        output_dir: a `str` or `Path`, the path to the download directory
        output_filename: a `str`, what to name the downloaded file.
            If this value is 'None', the filename is extracted from the URL.
            Default is 'None'.
        overwrite: a `bool`, indicates whether to overwrite the file if 
            it already exists, default is 'False'
    """
    output_dir = Path(output_dir)
    os.makedirs(output_dir, exist_ok=True)
    
    output_filename = output_filename or url.split('/')[-1]
    output_filepath = output_dir / output_filename
    
    if output_filepath.exists() and not overwrite:
        print(f"File {str(output_filepath)} already exists, nothing to do.")
        return
    bytestream = urllib.request.urlopen(url)
    with open(output_filepath, 'w+b') as output_file:
        output_file.write(bytestream.read())
        print(f"File saved to {str(output_filepath)}.")
```

Example:
```python
url = "https://www.dropbox.com/s/i3hgn0isnc90kkv/fico_heloc.csv"
download_file(url, output_dir='data')
```